### PR TITLE
Connect websockify to vnc over localhost

### DIFF
--- a/lib/desktop/session.rb
+++ b/lib/desktop/session.rb
@@ -190,7 +190,7 @@ module Desktop
             {},
             '/usr/bin/websockify',
             "0.0.0.0:#{websocket_port}",
-            "#{ip}:#{port}",
+            "127.0.0.1:#{port}",
             [:out, :err] => [log_file ,'w']
           )
         }

--- a/lib/desktop/version.rb
+++ b/lib/desktop/version.rb
@@ -25,5 +25,5 @@
 # https://github.com/alces-flight/flight-desktop
 # ==============================================================================
 module Desktop
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end


### PR DESCRIPTION
Fixes bug where websockify uses the primary IP which is often behind a firewall. Instead `websockify` should connect over localhost.

`develop` has been rebased off this commit.