### PR TITLE
Webify command to start websockify and screen grabber for active desktop sessions

### DIFF
--- a/lib/desktop/cli.rb
+++ b/lib/desktop/cli.rb
@@ -128,7 +128,7 @@ the host name and IP address that may be used to access the session,
 the X11 display number, the VNC port number, and the password required
 to access the session.
 
-The DESKTOP parameter should be either specify the session identity or
+The DESKTOP parameter should either specify the session identity or
 a display number prefixed with ':', e.g. ':1'.
 EOF
     end
@@ -155,7 +155,7 @@ EOF
       c.description = <<EOF
 Instruct an active interactive desktop session to terminate.
 
-The DESKTOP parameter should be either specify the session identity or
+The DESKTOP parameter should either specify the session identity or
 a display number prefixed with ':', e.g. ':1'.
 EOF
     end
@@ -188,6 +188,20 @@ EOF
     end
     alias_command :s, :start
     alias_command :st, :start
+
+    command :webify do |c|
+      cli_syntax(c, 'DESKTOP')
+      c.summary = 'Start web access support for an active desktop session'
+      c.action Commands, :webify
+      c.description = <<EOF
+Start required and optional web support programs for an active interactive
+desktop session.
+
+The DESKTOP parameter should either specify the session identity or
+a display number prefixed with ':', e.g. ':1'.
+EOF
+    end
+    alias_command :web, :webify
 
     command :set do |c|
       cli_syntax(c, '[NAME=VALUE...]')

--- a/lib/desktop/commands.rb
+++ b/lib/desktop/commands.rb
@@ -34,6 +34,7 @@ require_relative 'commands/set'
 require_relative 'commands/show'
 require_relative 'commands/start'
 require_relative 'commands/verify'
+require_relative 'commands/webify'
 
 module Desktop
   module Commands

--- a/lib/desktop/commands/webify.rb
+++ b/lib/desktop/commands/webify.rb
@@ -1,0 +1,85 @@
+# =============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Flight Desktop.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Desktop is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Desktop. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Desktop, please visit:
+# https://github.com/alces-flight/flight-desktop
+# ==============================================================================
+require_relative '../command'
+require_relative '../command_utils'
+require_relative '../config'
+require_relative '../errors'
+require_relative '../session'
+require_relative '../type'
+
+require 'whirly'
+
+module Desktop
+  module Commands
+    class Webify < Command
+      def run
+        if session.active?
+          puts "Starting web access support for desktop session #{Paint[session.uuid, :magenta]}:\n\n"
+          status_text = Paint["Starting web access support", '#2794d8']
+          print "   > "
+          begin
+            Whirly.start(
+              spinner: 'star',
+              remove_after_stop: true,
+              append_newline: false,
+              status: status_text
+            )
+            success = session.start_web_support_services
+            Whirly.stop
+          rescue
+            puts "\u274c #{status_text}\n\n"
+            raise
+          end
+          puts "#{success ? "\u2705" : "\u274c"} #{status_text}\n\n"
+        elsif session.local?
+          raise SessionOperationError, "session #{session.uuid} is not active"
+        else
+          raise SessionOperationError, "session #{session.uuid} is not local"
+        end
+      end
+
+      private
+      def uuid
+        @uuid ||= args[0][0] == ':' ? nil : args[0]
+      end
+
+      def display
+        @display ||= args[0][0] == ':' ? args[0][1..-1] : nil
+      end
+
+      def session
+        @session ||=
+          if uuid
+            Session[uuid]
+          else
+            Session.find_by_display(display) ||
+              raise(SessionNotFoundError, "no local active session found for display :#{display}")
+          end
+      end
+    end
+  end
+end


### PR DESCRIPTION
If websockify and the screen grabber programs are not installed when the desktop session is started they are not ran for that desktop session.  This commit introduces a new command `webify DESKTOP` that will start websockify and the screen grabber for an active session.

To simplify the implementation, the screen grabber is only started if the websockify process is about to be started.  It is therefore still possible to have an active, web accessible desktop session for which the screen grabber is not running and to have no way to fix this.
