### PR TITLE
Fix detecting the primary IP on azure

### DIFF
--- a/libexec/get-primary-ip
+++ b/libexec/get-primary-ip
@@ -43,6 +43,42 @@ network_is_azure() {
     [ "$(cat /sys/class/dmi/id/chassis_vendor)" == "Microsoft Corporation" ]
 }
 
+network_is_virtualbox() {
+  (
+    [ -f /sys/class/dmi/id/product_name ] &&
+      [ "$(cat /sys/class/dmi/id/product_name)" == "VirtualBox" ]
+  ) || (
+    [ -f /sys/class/dmi/id/board_name ] &&
+      [ "$(cat /sys/class/dmi/id/board_name)" == "VirtualBox" ]
+  ) || (
+    [ -f /sys/class/dmi/id/bios_version ] &&
+      [ "$(cat /sys/class/dmi/id/bios_version)" == "VirtualBox" ]
+  )
+}
+
+network_get_virtualbox_address() {
+  # For Vagrant/VirtualBox we want to avoid using the NAT device on eth0 if we
+  # can, otherwise all machines in the cluster will get the same primary IP
+  # address.  The NAT device always has the IP address 10.0.2.15
+  ip=$(network_get_iface_address $(network_get_route_iface 8.8.8.8))
+  if [ "$ip" == "10.0.2.15" ]; then
+    # This is the NAT device, we want to avoid that and use the address of
+    # the third device if we can.
+    ip=$( ip -o -4 address show \
+        | tail -n +3 \
+        | head -n 1 \
+        | sed 's/.*inet \([^\/ ]\+\).*/\1/g'
+    )
+    if [ "$ip" == "" ]; then
+        echo 10.0.2.15
+    else
+        echo "$ip"
+    fi
+  else
+      echo "$ip"
+  fi
+}
+
 network_get_route_iface() {
     local target_ip
     target_ip="$1"
@@ -75,6 +111,8 @@ elif network_is_azure; then
   else
     echo "$ip"
   fi
+elif network_is_virtualbox; then
+  network_get_virtualbox_address
 else
   network_get_iface_address $(network_get_route_iface 8.8.8.8)
 fi

--- a/libexec/get-primary-ip
+++ b/libexec/get-primary-ip
@@ -69,7 +69,12 @@ if network_is_ec2; then
     echo "$ip"
   fi
 elif network_is_azure; then
-  curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2017-08-01&format=text"
+  ip=$(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2017-08-01&format=text")
+  if [ -z "$ip" ]; then
+    network_get_iface_address $(network_get_route_iface 8.8.8.8)
+  else
+    echo "$ip"
+  fi
 else
   network_get_iface_address $(network_get_route_iface 8.8.8.8)
 fi


### PR DESCRIPTION
The existing method would only detect the primary IP if it is publicly accessible. In practice, this means it works for the head node but not compute nodes.

On compute nodes, it now falls back to finding an interface that can connect to `8.8.8.8`