### PR TITLE
CLI argument for persisting environment

### DIFF
--- a/lib/desktop/cli.rb
+++ b/lib/desktop/cli.rb
@@ -188,6 +188,7 @@ TEMPLATE
       c.summary = 'Start an interactive desktop session'
       c.action Commands, :start
       c.option '-g', '--geometry GEOMETRY', Geometry, 'Specify desktop geometry.'
+      c.option '--no-env-override', "Don't blank the session environment."
       c.slop.array '-a', '--app', APP_DESC, delimiter: nil, meta: '"BINARY [ARGUMENTS...]"'
       c.slop.string '-s', '--script', SCRIPT_DESC, delimiter: nil, meta: '"SCRIPT [ARGUMENTS...]"'
       c.description = <<EOF

--- a/lib/desktop/cli.rb
+++ b/lib/desktop/cli.rb
@@ -188,7 +188,8 @@ TEMPLATE
       c.summary = 'Start an interactive desktop session'
       c.action Commands, :start
       c.option '-g', '--geometry GEOMETRY', Geometry, 'Specify desktop geometry.'
-      c.option '--no-env-override', "Don't blank the session environment."
+      c.option '--override-env', "Blank the session environment (takes precedence over --no-override-env)."
+      c.option '--no-override-env', "Don't blank the session environment."
       c.slop.array '-a', '--app', APP_DESC, delimiter: nil, meta: '"BINARY [ARGUMENTS...]"'
       c.slop.string '-s', '--script', SCRIPT_DESC, delimiter: nil, meta: '"SCRIPT [ARGUMENTS...]"'
       c.description = <<EOF

--- a/lib/desktop/commands/start.rb
+++ b/lib/desktop/commands/start.rb
@@ -57,7 +57,7 @@ module Desktop
             success = session.start(
               geometry: @options.geometry || Config.geometry,
               script:   @options.script,
-	      no_env_override: @options.no_env_override
+              no_env_override: @options.no_env_override
             )
             start_apps(session)
             Whirly.stop

--- a/lib/desktop/commands/start.rb
+++ b/lib/desktop/commands/start.rb
@@ -57,8 +57,9 @@ module Desktop
             success = session.start(
               geometry: @options.geometry || Config.geometry,
               script:   @options.script,
-              override_env: @options.override_env,
-              no_override_env: @options.no_override_env
+              override_env: @options.override_env ||
+                              !@options.no_override_env &&
+                              Config.session_env_override
             )
             start_apps(session)
             Whirly.stop

--- a/lib/desktop/commands/start.rb
+++ b/lib/desktop/commands/start.rb
@@ -58,7 +58,7 @@ module Desktop
               geometry: @options.geometry || Config.geometry,
               script:   @options.script,
               override_env: @options.override_env,
-              no_override_env: @options.override_env
+              no_override_env: @options.no_override_env
             )
             start_apps(session)
             Whirly.stop

--- a/lib/desktop/commands/start.rb
+++ b/lib/desktop/commands/start.rb
@@ -57,6 +57,7 @@ module Desktop
             success = session.start(
               geometry: @options.geometry || Config.geometry,
               script:   @options.script,
+	      no_env_override: @options.no_env_override
             )
             start_apps(session)
             Whirly.stop

--- a/lib/desktop/commands/start.rb
+++ b/lib/desktop/commands/start.rb
@@ -57,7 +57,8 @@ module Desktop
             success = session.start(
               geometry: @options.geometry || Config.geometry,
               script:   @options.script,
-              no_env_override: @options.no_env_override
+              override_env: @options.override_env,
+              no_override_env: @options.override_env
             )
             start_apps(session)
             Whirly.stop

--- a/lib/desktop/session.rb
+++ b/lib/desktop/session.rb
@@ -182,10 +182,10 @@ module Desktop
           create_password_file
           install_session_script
           start_vnc_server(
-	    geometry: geometry,
-	    postinitscript: script,
-	    no_env_override: no_env_override
-	  ).tap do |started|
+            geometry: geometry,
+            postinitscript: script,
+            no_env_override: no_env_override
+          ).tap do |started|
             if started
               start_websocket_server
               start_grabber

--- a/lib/desktop/session.rb
+++ b/lib/desktop/session.rb
@@ -299,7 +299,7 @@ module Desktop
       if postinitscript
         args << '-postinitscript' << postinitscript
       end
-      override_env_bool = override_env || Config.session_env_override && !no_env_override
+      env_override = override_env || !no_override_env && Config.session_env_override
       IO.popen(
         {}.tap do |h|
           h['flight_DESKTOP_type_root'] = type.dir
@@ -321,7 +321,7 @@ module Desktop
           # `flight_DESKTOP_type_root and flight_DESKTOP_bg_image
           # directly; as done above.
           h['flight_DESKTOP_root'] = Config.root
-          if override_env_bool
+          if env_override
             h['USER'] = ENV['USER']
             h['HOME'] = ENV['HOME']
             h['LANG'] = ENV['LANG']
@@ -333,7 +333,7 @@ module Desktop
           *args,
           {
             err: [:child, :out],
-            unsetenv_others: override_env_bool
+            unsetenv_others: env_override
           }
         ]
       ) do |io|


### PR DESCRIPTION
This PR introduces a new command line option to `flight desktop start` which disables the regular behaviour of blanking the session environment and allows the environment variables of the host machine to persist. The option, `--no-env-override`, has simply been added to the logic used when deciding whether to reset the session environment.

Appropriate documentation has been added to `openflight-omnibus-builder` to describe this new argument.