### PR TITLE
Available geometries output

### DIFF
--- a/lib/desktop/command_utils.rb
+++ b/lib/desktop/command_utils.rb
@@ -113,7 +113,8 @@ EOF
           puts "IPs\t#{session.ips.join("|")}"
           puts "Name\t#{session.name}"
           puts "Geometry\t#{session.geometry}"
-          puts "Job ID\t#{session.job_id}" if session.job_id
+          puts "Job ID\t#{session.job_id}"
+          puts "Available Geometries\t#{session.available_geometries.join("|")}"
         end
       end
 

--- a/lib/desktop/commands/resize.rb
+++ b/lib/desktop/commands/resize.rb
@@ -40,8 +40,6 @@ module Desktop
             raise Commander::Command::CommandUsageError, "excess arguments for command 'resize'"
           end
           puts session.available_geometries
-                      .sort_by { |g| g.split('x').map(&:to_i) }
-                      .reverse
         else
           if args.length < args_needed
             raise Commander::Command::CommandUsageError, "insufficient arguments for command 'resize'"

--- a/lib/desktop/session.rb
+++ b/lib/desktop/session.rb
@@ -191,6 +191,8 @@ module Desktop
       @available_geometries ||=
         xrandr.drop(2)
               .map { |g| g.split(' ')[0] }
+              .sort_by { |g| g.split('x')[0].to_i }
+              .reverse
     end
 
     def xrandr

--- a/lib/desktop/session.rb
+++ b/lib/desktop/session.rb
@@ -191,7 +191,7 @@ module Desktop
       @available_geometries ||=
         xrandr.drop(2)
               .map { |g| g.split(' ')[0] }
-              .sort_by { |g| g.split('x')[0].to_i }
+              .sort_by { |g| g.split('x').map(&:to_i) }
               .reverse
     end
 


### PR DESCRIPTION
This PR updates the output of `flight show SESSION` for non-TTY sessions to include the list of available geometries for that session.

There has also been an update to the `Session#available_geometries` method to include a concluding sort call. Previously, the list was out of order, with the session's current geometry at the top of the list. Now the list is in the same order regardless of what the current setting is. Please note that this doesn't affect the `Session#geometry` method, which relies on the output of `Session#xrandr` being out of order to fetch the current geometry.