### PR TITLE
Allow configuring IP used for `DISPLAY`/`xrandr`

### DIFF
--- a/etc/config.yml.ex
+++ b/etc/config.yml.ex
@@ -41,4 +41,7 @@
 # Time spent attempting to connect to a remote desktop before timing out
 # (in seconds)
 #timeout: 2
-
+# Display IP network.  When using xrandr to configure a remote session, the
+# sesison's IP address in this network will be used.  If left unset, the first
+# private IP address will be used, falling back to the primary IP address.
+#display_network: 10.0.6.0/24

--- a/lib/desktop/config.rb
+++ b/lib/desktop/config.rb
@@ -101,6 +101,8 @@ module Desktop
     attribute :access_ip, required: false, defualt: ->() { NetworkUtils.primary_ip }
     attribute :access_host, required: false
 
+    attribute :display_network, required: false
+
     attribute :global_state_path, default: 'var/lib/desktop',
               transform: relative_to(root_path)
     attribute :user_state_path, default: desktop_path.join('state'),

--- a/lib/desktop/network_utils.rb
+++ b/lib/desktop/network_utils.rb
@@ -60,6 +60,19 @@ module Desktop
           IPAddr.new(h).include?(ip_addr)
         end
       end
+
+      # Return the IP address to use for the `DISPLAY` environment variable.
+      def get_display_ip(ips)
+        if Config.display_network.nil?
+          ips.detect { |ip| private_ip?(ip) } || primary_ip
+        else
+          display_network = IPAddr.new(Config.display_network)
+          ips.detect do |ip|
+            ip = IPAddr.new(ip) if ip.is_a?(String)
+            display_network.include?(ip)
+          end
+        end
+      end
     end
   end
 end

--- a/lib/desktop/session.rb
+++ b/lib/desktop/session.rb
@@ -133,7 +133,8 @@ module Desktop
     end
 
     def display_full
-      (local? ? '' : ip) + ":#{display}"
+      display_ip = local? ? "" : NetworkUtils.get_display_ip(ips)
+      "#{display_ip}:#{display}"
     end
 
     def port


### PR DESCRIPTION
The IP address used in the `DISPLAY` environment variable used by the `xrandr` command is now configurable.  If not set it will default to the first private IP address for the session, falling back to the session's primary IP address if it has no private IP addresses.  The order of the session's IP addresses are determined by the `ip address show` command.

In addition to allowing the IP address to be configured, the default behaviour is changed.  Previously, the session's primary IP address was used, now the session's first private IP address is used.  It is assumed that will be correct in most cases.