### PR TITLE
Disable hidden desktop types

### DIFF
--- a/lib/desktop/commands/avail.rb
+++ b/lib/desktop/commands/avail.rb
@@ -40,7 +40,6 @@ module Desktop
             Table.emit do |t|
               headers 'Name', 'Summary', 'State'
               Type.each do |t|
-                next if t.hidden
                 row Paint[t.name, :cyan],
                     word_wrap.call(
                       "#{Paint[t.summary, :green]}".tap do |s|
@@ -54,7 +53,6 @@ module Desktop
           end
         else
           Type.each do |t|
-            next if t.hidden
             puts [t.name, t.summary.chomp.gsub("\n"," "), t.url, t.verified? ? 'Verified' : 'Unverified'].join("\t")
           end
         end

--- a/lib/desktop/type.rb
+++ b/lib/desktop/type.rb
@@ -69,7 +69,7 @@ module Desktop
                   begin
                     md = YAML.load_file(File.join(d,'metadata.yml'))
                     t = Type.new(md, d)
-                    h[md[:name].to_sym] = t if t.supports_host_arch?
+                    h[md[:name].to_sym] = t if t.supports_host_arch? && !t.disabled?
                   rescue
                     nil
                   end
@@ -108,7 +108,7 @@ module Desktop
     # See Type.default for the actual default desktop for the current user.
     attr_reader :default
     attr_reader :arch
-    attr_reader :hidden
+    attr_reader :disabled
     attr_reader :dir
 
     def initialize(md, dir)
@@ -118,9 +118,13 @@ module Desktop
       @default = md[:default]
       @dir = dir
       @arch = md[:arch] || []
-      @hidden = (File.basename(dir)[0] == '.' || md[:hidden] || false)
+      @disabled = (File.basename(dir)[0] == '.' || md[:disabled] || false)
       @scriptable = md[:scriptable]
       @resizable = md[:resizable]
+    end
+
+    def disabled?
+      @disabled
     end
 
     def scriptable?


### PR DESCRIPTION
`flight desktop` previously had functionality for hiding desktop types from the output of the `avail` command. 

This PR disables these hidden types so they are treated by all commands as an unknown desktop type.

To disable a desktop type, add a line with `:disabled: true` to the metadata file for the desktop type. Remove the line or set `:disabled: false` to re-enable.