### PR TITLE
Don't use -rfbwait if running RHEL 8

### DIFF
--- a/libexec/vncserver
+++ b/libexec/vncserver
@@ -49,6 +49,16 @@ $geometry = "1024x768";
 #$depth = 16;
 $xauthorityFile = "$ENV{XAUTHORITY}" || "$ENV{HOME}/.Xauthority";
 
+my $release = "/etc/redhat-release";
+if (-e $release) {
+    open DATA, $release;
+    my @array_of_data = <DATA>;
+    if ($_ =~ m/release 8/i) {
+        $distro = "rhel8";
+    }
+    close DATA
+}
+
 chop($host = `uname -n`);
 
 if (-d "/etc/X11/fontpath.d") {
@@ -190,7 +200,7 @@ $cmd .= " -auth $xauthorityFile";
 $cmd .= " -geometry $geometry" if ($geometry);
 $cmd .= " -depth $depth" if ($depth);
 $cmd .= " -pixelformat $pixelformat" if ($pixelformat);
-$cmd .= " -rfbwait 30000";
+$cmd .= " -rfbwait 30000" if ($distro != "rhel8");
 $cmd .= " -rfbauth $opt{'-vncpasswd'}";
 $cmd .= " -rfbport $vncPort";
 $cmd .= " -fp $fontPath" if ($fontPath);


### PR DESCRIPTION
The TigerVNC package on Centos 7 has support for an option called `-rfbwait`, which we use in `libexec/vncserver`. The TigerVNC package on Centos 8 has since removed support for this option. This PR only changes the `Xvnc` call to omit the `-rfbwait` option if the system is running RHEL 8.

We may be able to remove the option entirely, but I'm not sure what it does so I'll leave that decision to someone who does.