### PR TITLE
Fix missing previews on EL9

### DIFF
--- a/lib/desktop/session.rb
+++ b/lib/desktop/session.rb
@@ -348,9 +348,7 @@ module Desktop
     end
 
     def start_grabber
-      if File.executable?('/usr/bin/xwd') &&
-        File.executable?('/usr/bin/xwdtopnm') &&
-        File.executable?('/usr/bin/pnmtopng')
+      if File.executable?('/usr/bin/import')
         pid = fork {
           log_file = File.join(
             dir,

--- a/libexec/grabber
+++ b/libexec/grabber
@@ -32,10 +32,8 @@ trap 'kill $(jobs -p)' EXIT
 
 sleep 5
 while true; do
-  if [ -x /usr/bin/xwd -a -x /usr/bin/xwdtopnm -a -x /usr/bin/pnmtopng ]; then
-    /usr/bin/xwd -root -silent -display ":${display}" | \
-      /usr/bin/xwdtopnm | \
-      /usr/bin/pnmtopng > "${dir}"/session.png
+  if [ -x /usr/bin/import ]; then
+    /usr/bin/import -window root -display ":${display}" -silent "${dir}"/session.png
   fi
   sleep 60
 done


### PR DESCRIPTION
This PR fixes the missing desktop preview images for EL9 machines by using `ImageMagick`'s `import` to grab screenshots since `xwd` is deprecated.