### PR TITLE
Add ed25519 and bcrypt gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem 'xdg', git: 'https://github.com/bkuhlmann/xdg', tag: '3.0.2'
 gem 'flight_configuration', github: 'openflighthpc/flight_configuration', tag: '0.4.1'
 gem 'ronn'
 gem 'whirly'
+gem 'ed25519'
+gem 'bcrypt_pbkdf'
 gem 'sys-proctable'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,11 +15,13 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    bcrypt_pbkdf (1.1.0)
     commander-openflighthpc (2.2.0)
       highline (> 1.7.2)
       paint (~> 2.1.0)
       slop (~> 4.8)
     diff-lcs (1.5.0)
+    ed25519 (1.3.0)
     equatable (0.6.1)
     fakefs (1.5.1)
     ffi (1.11.1)
@@ -84,7 +86,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt_pbkdf
   commander-openflighthpc (~> 2.2.0)
+  ed25519
   fakefs
   flight_configuration!
   ronn


### PR DESCRIPTION
It would seem that changes to OpenSSH on EL8+ store keys by default in RFC4716 format (`-----BEGIN OPENSSH PRIVATE KEY-----`) instead of PEM format (`-----BEGIN RSA PRIVATE KEY-----`). The latter requires `ed25519` to be available. This PR adds that gem.