### PR TITLE
Fix Doctor Output & Screen Capture Check

### DIFF
--- a/lib/desktop/commands/doctor.rb
+++ b/lib/desktop/commands/doctor.rb
@@ -41,9 +41,7 @@ module Desktop
 
       OPTIONAL_PROGS = {
         'Screen capture handling' => {
-          'X window capture' => '/usr/bin/xwd',
-          'Image converter (stage 1)' => '/usr/bin/xwdtopnm',
-          'Image converter (stage 2)' => '/usr/bin/pnmtopng',
+          'X window capture' => '/usr/bin/import',
         },
         'Networking' => {
           'Websocket provider' => Config.websockify_paths,

--- a/lib/desktop/commands/doctor.rb
+++ b/lib/desktop/commands/doctor.rb
@@ -137,13 +137,14 @@ module Desktop
             section_success = true
             h.each do |k,v|
               sr = SearchResult.new(v).run
-              puts "   > #{sr.success ? "\u2705" : "\u274c"} #{k} (#{sr.formatted_paths})"
+              section_output << "\n      > #{sr.success ? "\u2705" : "\u274c"} #{k} (#{sr.formatted_paths})"
               section_success &&= sr.success
             end
             if !section_success
               section_summary << " * #{Paint["OPTIONAL",:bright,:yellow]} - #{s} dependencies are not satisfied."
             end
-            puts "\n   > #{section_success ? "\u2705" : "\u274c"} #{s}\n#{section_output}"
+            puts "\n   > #{section_success ? "\u2705" : "\u274c"} #{s}"
+            puts "#{section_output}"
           end
           puts "\n== #{Paint["Summary",:bright]} ==\n\n"
           if section_summary.empty? && critical_success


### PR DESCRIPTION
This PR: 
- Checks for `import` command instead of the deprecated `xwd` tools (introduced in #56)
- Fixes the output ordering of the doctor checks (more info below)

Before this PR, doctor output looked like (these examples include new screen capture fix): 
```
Verifying critical dependencies:

   > ✅ VNC session management (/opt/flight/opt/desktop/libexec/vncserver)
   > ✅ X VNC server (/usr/bin/Xvnc)
   > ✅ X authority file utility (/usr/bin/xauth)
   > ✅ VNC password management (/usr/bin/vncpasswd)

Verifying optional dependencies:
   > ✅ X window capture (/usr/bin/import)

   > ✅ Screen capture handling
   > ✅ Websocket provider (/opt/flight/opt/websockify/bin/websockify)

   > ✅ Networking
   > ✅ Password generator (/usr/bin/apg)

   > ✅ Improved passwords

== Summary ==

 * OK - all dependencies are satisfied!
```

The fix reorders the output (using the, already half-implemented, `section_output` variable) so the section headings appear before the checks within (and are intended for easier readability):
```
Verifying critical dependencies:

   > ✅ VNC session management (/opt/flight/opt/desktop/libexec/vncserver)
   > ✅ X VNC server (/usr/bin/Xvnc)
   > ✅ X authority file utility (/usr/bin/xauth)
   > ✅ VNC password management (/usr/bin/vncpasswd)

Verifying optional dependencies:

   > ✅ Screen capture handling

      > ✅ X window capture (/usr/bin/import)

   > ✅ Networking

      > ✅ Websocket provider (/opt/flight/opt/websockify/bin/websockify)

   > ✅ Improved passwords

      > ✅ Password generator (/usr/bin/apg)

== Summary ==

 * OK - all dependencies are satisfied!

```

This works in the event that sections are missing dependencies
```
Verifying critical dependencies:

   > ✅ VNC session management (/opt/flight/opt/desktop/libexec/vncserver)
   > ✅ X VNC server (/usr/bin/Xvnc)
   > ✅ X authority file utility (/usr/bin/xauth)
   > ✅ VNC password management (/usr/bin/vncpasswd)

Verifying optional dependencies:

   > ❌ Screen capture handling

      > ❌ X window capture (/usr/bin/import-fail)

   > ✅ Networking

      > ✅ Websocket provider (/opt/flight/opt/websockify/bin/websockify)

   > ✅ Improved passwords

      > ✅ Password generator (/usr/bin/apg)

== Summary ==

 * OPTIONAL - Screen capture handling dependencies are not satisfied.
```